### PR TITLE
Nothing wrong with using explicit self

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -982,7 +982,7 @@ Style/RedundantReturn:
 Style/RedundantSelf:
   Description: Don't use self where it's not needed.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#no-self-unless-required
-  Enabled: true
+  Enabled: false
 Style/RegexpLiteral:
   EnforcedStyle: slashes
   SupportedStyles:


### PR DESCRIPTION
Rational: prepending self makes it obvious we are dealing with the
instance attribute. Since it otherwise could be a local or
parameter. Because self is required for assignment it would make sense
to not frown upon its use when reading an attribute.

Personally I usually don't care for self in all cases but for instance
attributes I think it helps distinguish that I have an attribute and not
calling a method thus no need to look for a method.

On the other hand changing an attribute to a method would not require
changing the calling site if adhering to the principle of omitting
self. But would you actually ever trust this? I would definiately run a
few git greps in either case and then changing the calling site would
not be a problem either.
