### PR TITLE
The check for calling convention is troublesome

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -784,7 +784,7 @@ Style/LambdaCall:
   - braces
   Description: Use lambda.call(...) instead of lambda.(...).
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#proc-call
-  Enabled: true
+  Enabled: false
 Style/LeadingCommentSpace:
   Description: Comments should start with a space.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#hash-space


### PR DESCRIPTION
We don't want .call but .() but there is another rule that says dont use
.() without arguments. These two conflict and sometimes .call is the
proper choice and other times it makes more sense with .().

Lets not have conflicting rules.
