### PR TITLE
Add line length rule

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -32,6 +32,10 @@ AllCops:
 # Please try to keep this list alphabetically
 # –––––––––––––––––––––––––––––––––––––––––––
 
+# 80 characters can sometimes cause weird line breaks that make code less readable.
+Metrics/LineLength:
+  Max: 100
+
 # This is a pure performance immprovement without any other positive side-effects.
 # We're willing to accept the performance penalty favoring code readability.
 Performance/CaseWhenSplat:


### PR DESCRIPTION
I think 100 is a good compromise between the 80 char rule (that I find sometimes makes code less readable) and super long lines.
