### PR TITLE
Allow trailing comma in hash-like definitions.

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -85,3 +85,7 @@ Style/RedundantSelf:
 Style/StringLiterals:
   Enabled: false
 
+# Admit that you too copy paste rows in a Hash.
+# To prevent micro-managing the commas, we allow a trailing coma even in the last row.
+Style/TrailingCommaInLiteral:
+  Enabled: false


### PR DESCRIPTION
I know it is not entirely intuitive but I suggest it prevents copy-paste errors.

``` ruby
def to_hash
  {
    some: :thing,
    and: :more,  # <- this comma should be allowed
  }
end
```
