### PR TITLE
Enforce single quotes in sass files

### DIFF
--- a/scss-lint.yml
+++ b/scss-lint.yml
@@ -1,4 +1,5 @@
 # The default configuration can be modified below.
+# Hound uses https://raw.githubusercontent.com/houndci/linters/master/config/scss.yml
 # See https://github.com/brigade/scss-lint/blob/master/config/default.yml
 
 # Please try to keep this file alphabetically.
@@ -15,3 +16,9 @@ linters:
   PropertySortOrder:
     separate_groups: true
     order: concentric
+
+  # We enforce single quotes in rubocop, and it's the default in scss-lint
+  # This overrides the double quote default in hounds' config file
+  StringQuotes:
+    enabled: true
+    style: single_quotes 


### PR DESCRIPTION
We enforce single quotes in rubocop, and it's the default in scss-lint
This overrides the double quote default in [hounds' config file](https://raw.githubusercontent.com/houndci/linters/master/config/scss.yml)