### PR TITLE
Disable selector format rule in scss-lint

### DIFF
--- a/scss-lint.yml
+++ b/scss-lint.yml
@@ -17,6 +17,10 @@ linters:
     separate_groups: true
     order: concentric
 
+  # This enables us to use underscores in BEM-style classes
+  SelectorFormat:
+    enabled: false
+
   # We enforce single quotes in rubocop, and it's the default in scss-lint
   # This overrides the double quote default in hounds' config file
   StringQuotes:


### PR DESCRIPTION
Otherwise we get this warning : 
![fineart 2016-12-14 13-06-31](https://cloud.githubusercontent.com/assets/2894651/21181555/cb511444-c1fe-11e6-9cca-45267a65478b.jpg)
