### PR TITLE
Disable Naming/UncommunicativeMethodParamName cop

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -62,6 +62,11 @@ Metrics/ModuleLength:
     - spec/**/*.rb
     - spec_legacy/**/*.rb
 
+# This flags ** and _ as false positives and creates noise. We are careful enough with
+# naming during code reviews that we don't need this
+Naming/UncommunicativeMethodParamName:
+  Enabled: false
+
 # This is a pure performance immprovement without any other positive side-effects.
 # We're willing to accept the performance penalty favoring code readability.
 Performance/CaseWhenSplat:


### PR DESCRIPTION
This flags `**` and `_` as false positives and creates noise. We are careful enough with naming during code reviews that we don't need this

Cf. https://github.com/bukowskis/auktion/pull/4264