### PR TITLE
Disable RSpec/NestedGroups cop

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -106,6 +106,10 @@ RSpec/ExampleLength:
 RSpec/MultipleExpectations:
   Enabled: false
 
+# We use nested groups to keep our context descriptions short.
+RSpec/NestedGroups:
+  Enabled: false
+
 # UTF-8 ––––– in comments can improve readability ✔
 # It's allowed as method names, so maybe it should be allowed as comment.
 Style/AsciiComments:


### PR DESCRIPTION
When writing tests we usually use nested groups to keep our context description short:

```ruby
context 'phone number validations' do
  context 'when created by employee' do
    context 'when no phone number is given' do
      it 'is valid' do
        # ...
```

Instead of
```ruby
context 'phone number validations created by employee when no phone number is given' do
  it 'is valid' do
    # ...
```