### PR TITLE
[sass-lint] Disable indentation checking because of bug

### DIFF
--- a/sass-lint.yml
+++ b/sass-lint.yml
@@ -13,6 +13,10 @@ rules:
   # This is a common-sense rule that Hound has on WARN. We enforce it.
   empty-line-between-blocks: 2
 
+  # Because of a long-standing bug we disable indentation checking.
+  # See https://github.com/sasstools/sass-lint/issues/591#issuecomment-314887197
+  indentation: 0
+
   # We agree that it is better for the eye to see 0.4 instead of just .4
   # So much so, that we enforce the leading zero to be used.
   # Hound default is WARN.


### PR DESCRIPTION
CSS Grid is triggered as invalid, see https://github.com/sasstools/sass-lint/issues/591#issuecomment-314887197

#### Basically we're preventing this error:

---

![screen shot 2019-02-05 at 09 44 12](https://user-images.githubusercontent.com/1029840/52261763-ad0a2800-292a-11e9-9b85-a1aa5265d4db.jpg)
