### PR TITLE
Upgrade rubocop 0.54.0 -> 0.63.0

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -15,3 +15,6 @@ slim_lint:
   enabled: true
 
 fail_on_violations: true
+
+rubocop:
+  version: 0.63.0


### PR DESCRIPTION
I assume this will also upgrade rubocop-rspec?
I'm getting errors on Hound that I don't have locally.
See https://github.com/rubocop-hq/rubocop-rspec/pull/666

See also http://help.houndci.com/configuration/linter-versioning

# I want to prevent this outdated error:

![screen shot 2019-02-11 at 13 18 24](https://user-images.githubusercontent.com/1029840/52562848-1e048080-2e00-11e9-808d-accace2037b1.jpg)
