### PR TITLE
Disable EmptyLineAfterGuardClause cop

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -43,6 +43,9 @@ Capybara/FeatureMethods:
 FactoryBot/StaticAttributeDefinedDynamically:
   enabled: false
 
+Layout/EmptyLineAfterGuardClause:
+  Enabled: false
+
 # We usually catch those in code reviews and this metric is causing
 # a lot of noise and false positives.
 Metrics/AbcSize:


### PR DESCRIPTION
This cop has been introduced in rubocop 0.56 and is inconsistent with how we have
been writing our guard clauses so far.

See https://github.com/rubocop-hq/rubocop/blob/master/manual/cops_layout.md#layoutemptylineafterguardclause

This disables the cop in order to avoid having many new violations in our code base
for a rule that hasn't been causing issues until now.