### PR TITLE
updated readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ These are the coding style conventions we adhere to.
 
 ## Installation
 
-docker-compose build pronto
+docker compose build runner
 
 Create a `.rubocop.yml` in every repository with this content:
 


### PR DESCRIPTION
Updated readme. it says "docker-compose build pronto" but it should be "docker compose build runner"